### PR TITLE
Signalize impossible hotfix 2

### DIFF
--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -36,6 +36,50 @@ extern "C" {
 void process_commands(FILE* inout);
 }
 
+//! @brief Check, if filament is not present in FINDA
+//!
+//! blocks, until filament is not removed and button pushed
+//!
+//! button | action
+//! ------ | ------
+//! right  | continue after error
+//!
+//! LED indication of states
+//!
+//! RG | RG | RG | RG | RG | meaning
+//! -- | -- | -- | -- | -- | ------------------------
+//! b0 | b0 | b0 | b0 | b0 | Error, filament detected, still present
+//! 0b | 0b | 0b | 0b | 0b | Error, filament detected, no longer present, continue by right button click
+//!
+//! @n R - Red LED
+//! @n G - Green LED
+//! @n 1 - active
+//! @n 0 - inactive
+//! @n b - blinking
+
+void check_filament_not_present()
+{
+    // if FINDA is sensing filament do not home
+    while (digitalRead(A1) == 1)
+    {
+        while (Btn::right != buttonClicked())
+        {
+            if (digitalRead(A1) == 1)
+            {
+                shr16_set_led(0x2aa);
+            }
+            else
+            {
+                shr16_set_led(0x155);
+            }
+            delay(300);
+            shr16_set_led(0x000);
+            delay(300);
+        }
+    }
+    isFilamentLoaded = false;
+}
+
 //! @brief Initialization after reset
 //!
 //! button | action
@@ -52,8 +96,6 @@ void process_commands(FILE* inout);
 //! 00 | 00 | 0b | 00 | 00 | spi initialized
 //! 00 | 0b | 00 | 00 | 00 | tmc2130 initialized
 //! 0b | 00 | 00 | 00 | 00 | A/D converter initialized
-//! b0 | b0 | b0 | b0 | b0 | Error, filament detected, still present
-//! 0b | 0b | 0b | 0b | 0b | Error, filament detected, no longer present, continue by right button click
 //!
 //! @n R - Red LED
 //! @n G - Green LED
@@ -243,9 +285,9 @@ void process_commands(FILE* inout)
 		else if (sscanf_P(line, PSTR("L%d"), &value) > 0)
 		{
 			// Load filament
-			if ((value >= 0) && (value < EXTRUDERS) && !isFilamentLoaded)
+			if ((value >= 0) && (value < EXTRUDERS))
 			{
-
+			    check_filament_not_present();
 				select_extruder(value);
 				feed_filament();
 

--- a/MM-control-01/main.h
+++ b/MM-control-01/main.h
@@ -6,6 +6,7 @@
 #include "config.h"
 
 void manual_extruder_selector();
+void check_filament_not_present();
 
 // system state
 extern int8_t sys_state;

--- a/MM-control-01/motion.cpp
+++ b/MM-control-01/motion.cpp
@@ -597,23 +597,7 @@ bool home_idler(bool toLastFilament)
 bool home_selector()
 {
     // if FINDA is sensing filament do not home
-    while (digitalRead(A1) == 1)
-    {
-        while (Btn::right != buttonClicked())
-        {
-            if (digitalRead(A1) == 1)
-            {
-                shr16_set_led(0x2aa);
-            }
-            else
-            {
-                shr16_set_led(0x155);
-            }
-            delay(300);
-            shr16_set_led(0x000);
-            delay(300);
-        }
-    }
+    check_filament_not_present();
 	 
     move(0, -100,0); // move a bit in opposite direction
 
@@ -654,7 +638,6 @@ void home()
 
 	shr16_set_led(0x000);
 	
-	isFilamentLoaded = false; 
 	shr16_set_led(1 << 2 * (4-active_extruder));
 
   isHomed = true;


### PR DESCRIPTION
Signalize (red LEDs blinking), that it is not possible to load filament, if there is already filament loaded to nozzle. But return OK to printer and listen to next commands. This allow to initiate unload filament from printer.

Alternative fix would be only apply first commit. In such case, MMU is blocked until user doesn't remove filament by hand and press the button.

I recommend to apply both commits.

Anyway in both cases, it doesn't block path to be fixed better in printer (Do not issue some commands, if filament is sensed.)