### PR TITLE
On branch load_reload_using_bowdenlength

### DIFF
--- a/MM-control-01/Buttons.cpp
+++ b/MM-control-01/Buttons.cpp
@@ -203,6 +203,8 @@ void settings_bowden_length()
 
 		} while (buttonClicked() != Btn::middle);
 
+		//because this depends on the correct setting of the PREVIOUS filament loaded, set it correctly...
+		previous_extruder = active_extruder;
 		unload_filament_withSensor();
 	}
 }

--- a/MM-control-01/permanent_storage.cpp
+++ b/MM-control-01/permanent_storage.cpp
@@ -81,7 +81,27 @@ static bool validBowdenLen (const uint16_t BowdenLength)
 //! @return stored bowden length
 uint16_t BowdenLength::get()
 {
-	uint8_t filament = active_extruder;
+	return BowdenLength::getForExtruder(active_extruder);
+}
+
+
+
+//! @brief Get bowden length for previous filament
+//!
+//! Returns stored value
+//! @return stored bowden length for previous extruder
+uint16_t BowdenLength::getPrevious()
+{
+	return BowdenLength::getForExtruder(previous_extruder);
+}
+
+
+//! @brief Get bowden length for extruder as passed by argument
+//!
+//! Returns stored value
+//! @return stored bowden length for specified extruder
+uint16_t BowdenLength::getForExtruder(uint8_t filament)
+{
 	if (validFilament(filament))
 	{
 		uint16_t bowdenLength = eeprom_read_word(&(eepromBase->eepromBowdenLen[filament]));
@@ -99,8 +119,6 @@ uint16_t BowdenLength::get()
 
 	return eepromBowdenLenDefault;
 }
-
-
 //! @brief Construct BowdenLength object which allows bowden length manipulation
 //!
 //! To be created on stack, new value is permanently stored when object goes out of scope.

--- a/MM-control-01/permanent_storage.cpp
+++ b/MM-control-01/permanent_storage.cpp
@@ -93,7 +93,11 @@ uint16_t BowdenLength::get()
 //! @return stored bowden length for previous extruder
 uint16_t BowdenLength::getPrevious()
 {
-	int extruder = active_extruder; //Should be previous_extruder, but the integration build failed, this is for testing...
+	// The following use of "previous_extruder" is OK, as it is defined as a global variable in mmctl.cpp, just like "active_extruder".
+	// However.... The Travis build fails at this point, because in the "tests" folder, using in the build of test.sh it is not defined (only active_extruder is in there).
+	// To me this seems a problem of the build scripts that Travis build is now executing...
+	// For now I added a declaration in this "..Tests/mmctrl.h" as well...
+	int extruder = previous_extruder;
 	return BowdenLength::getForExtruder(extruder);
 }
 

--- a/MM-control-01/permanent_storage.cpp
+++ b/MM-control-01/permanent_storage.cpp
@@ -81,7 +81,8 @@ static bool validBowdenLen (const uint16_t BowdenLength)
 //! @return stored bowden length
 uint16_t BowdenLength::get()
 {
-	return BowdenLength::getForExtruder(active_extruder);
+	int extruder = active_extruder;
+	return BowdenLength::getForExtruder(extruder);
 }
 
 
@@ -92,7 +93,8 @@ uint16_t BowdenLength::get()
 //! @return stored bowden length for previous extruder
 uint16_t BowdenLength::getPrevious()
 {
-	return BowdenLength::getForExtruder(previous_extruder);
+	int extruder = previous_extruder;
+	return BowdenLength::getForExtruder(extruder);
 }
 
 

--- a/MM-control-01/permanent_storage.cpp
+++ b/MM-control-01/permanent_storage.cpp
@@ -100,7 +100,7 @@ uint16_t BowdenLength::getPrevious()
 //!
 //! Returns stored value
 //! @return stored bowden length for specified extruder
-uint16_t BowdenLength::getForExtruder(uint8_t filament)
+uint16_t BowdenLength::getForExtruder(int filament)
 {
 	if (validFilament(filament))
 	{

--- a/MM-control-01/permanent_storage.cpp
+++ b/MM-control-01/permanent_storage.cpp
@@ -93,7 +93,7 @@ uint16_t BowdenLength::get()
 //! @return stored bowden length for previous extruder
 uint16_t BowdenLength::getPrevious()
 {
-	int extruder = previous_extruder;
+	int extruder = active_extruder; //Should be previous_extruder, but the integration build failed, this is for testing...
 	return BowdenLength::getForExtruder(extruder);
 }
 

--- a/MM-control-01/permanent_storage.cpp
+++ b/MM-control-01/permanent_storage.cpp
@@ -100,8 +100,10 @@ uint16_t BowdenLength::getPrevious()
 //!
 //! Returns stored value
 //! @return stored bowden length for specified extruder
-uint16_t BowdenLength::getForExtruder(int filament)
+uint16_t BowdenLength::getForExtruder(int extruder)
 {
+	uint8_t filament = extruder;
+	
 	if (validFilament(filament))
 	{
 		uint16_t bowdenLength = eeprom_read_word(&(eepromBase->eepromBowdenLen[filament]));

--- a/MM-control-01/permanent_storage.h
+++ b/MM-control-01/permanent_storage.h
@@ -18,6 +18,8 @@ class BowdenLength
 {
 public:
 	static uint16_t get();
+	static uint16_t getPrevious();
+	static uint16_t getForExtruder(uint8_t filament);
 	static const uint8_t stepSize = 10u; //!< increase()/decrease() bowden length step size
 	BowdenLength();
 	bool increase();

--- a/MM-control-01/permanent_storage.h
+++ b/MM-control-01/permanent_storage.h
@@ -19,7 +19,7 @@ class BowdenLength
 public:
 	static uint16_t get();
 	static uint16_t getPrevious();
-	static uint16_t getForExtruder(uint8_t filament);
+	static uint16_t getForExtruder(int extruder);
 	static const uint8_t stepSize = 10u; //!< increase()/decrease() bowden length step size
 	BowdenLength();
 	bool increase();

--- a/Tests/mmctl.h
+++ b/Tests/mmctl.h
@@ -10,6 +10,9 @@
 
 extern int active_extruder;
 
+// added to use in the main branch as well and to prevent Travis build problems.
+// Probably not relevant for this tests folder....
+extern int previous_extruder;
 
 
 #endif /* MMCTL_H_ */

--- a/Tests/mmctl.h
+++ b/Tests/mmctl.h
@@ -9,10 +9,10 @@
 #define MMCTL_H_
 
 extern int active_extruder;
-
-// added to use in the main branch as well and to prevent Travis build problems.
-// Probably not relevant for this tests folder....
 extern int previous_extruder;
+// "previous_extruder" was added to use in the main branch as well and to prevent Travis build problems.
+// Probably not relevant for this "Tests" folder....
+
 
 
 #endif /* MMCTL_H_ */

--- a/Tests/permanent_storage_test.cpp
+++ b/Tests/permanent_storage_test.cpp
@@ -9,6 +9,11 @@
 #include <cstddef>
 
 int active_extruder = -1;
+// previous_extruder is in the MM-control-01\mmctl.h defined as external int.
+// Because in a pull request is is now correctly used in there, previous_extruder 
+// also must be defined in this test code.
+// It is declared - like active_extruder at this place, in the same scope. 
+int previous_extruder = 0;
 static unsigned long writes = 0;
 static int corrupt = -1;
 


### PR DESCRIPTION
Changes to be committed:
	modified:   Buttons.cpp
	modified:   motion.cpp
	modified:   permanent_storage.cpp
	modified:   permanent_storage.h

This fix is important for MMU2 units that have configured and calibrated a longer PTFE tube.
Before the fix: unload was using the "stock" length, programmed as a constant + extra length.
This resulted in poor and unnecesarily slow unloading.

It addresses issue #100

The printing time saved, on an average print job with 1000 toolchanges was 2.5 hours!

With this implementation accurate and fast loading and unloading filament using the configured bowden
length of the tubes is realized.

For obtaining the bowden length for the loaded tube, an additional method: BowdenLength::getPrevious()
was implemented/ This ensures the correct unload distance (for the old bowden, rather than the material to be loaded
material) could be obtained.

When checking for all occurrences of the unload routine, also the calibration routine (in Buttons.cpp)
was discovered and had to reflect the correct "previous" material used, or the obtained bowdenlenth would
be incorrect.

Constants were introduced to reflect the speeds / acceleration / deceleration / and points of
acceleration/deceleration, so that they can easily be tuned, independently of changing the program.
These constants are in motion.cpp.

I used the "fast" settings on my Prusa MK3/MMU during 50 hours of printing successfully for ~3000 toolchanges.
They were tested with PLA. The settings as provided contain the somewhat slower load/unload speeds.
These are the values used I found in the code as they were before this change.

It is possible that this is required for e.g. flex material, so I was conservative bumping up the speed
constants to the FAST values that I use.