### PR TITLE
Fix consume reset after power up. Do not cause drive error if EEPROM …

### DIFF
--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -231,12 +231,13 @@ void setup()
         enterSetup = true;
     }
 
+    tmc2130_init(HOMING_MODE);
+    tmc2130_read_gstat(); //consume reset after power up
     uint8_t filament;
     if(FilamentLoaded::get(filament))
     {
         motion_set_idler(filament);
     }
-    tmc2130_read_gstat(); //consume reset after power up
 
 	if (digitalRead(A1) == 1) isFilamentLoaded = true;
 


### PR DESCRIPTION
…is clear.

To successfully consume reset flag, tmc2130 needs to be initialized. Tmc2130 is initialized in motion_set_idler() only conditionally based on FilamentLoaded::get() return value. FilamentLoaded::get() returns false if EEPROM is erased.