### PR TITLE
Increase idler running current to 910 mA.

### DIFF
--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -76,10 +76,10 @@
 #define AX_IDL 2
 
 // currents
-#define CURRENT_HOLDING_STEALTH {1, 7, 16}
-#define CURRENT_HOLDING_NORMAL {1, 10, 22}
-#define CURRENT_RUNNING_STEALTH {35, 35, 35}
-#define CURRENT_RUNNING_NORMAL {30, 35, 35}
+#define CURRENT_HOLDING_STEALTH {1, 7, 16}  // {?,?,570 mA}
+#define CURRENT_HOLDING_NORMAL {1, 10, 22}  // {?,?,570 mA}
+#define CURRENT_RUNNING_STEALTH {35, 35, 45} // {?,?,910 mA}
+#define CURRENT_RUNNING_NORMAL {30, 35, 47} // {?,?,910 mA}
 #define CURRENT_HOMING {1, 35, 30}
 
 //mode


### PR DESCRIPTION
Maximum idler motor coil current is specified as 1000 mA, but with current closer to 1000 mA, current was more oscillating near maximum value, signalizing magnet saturation and decreased coil inductance.