### PR TITLE
Fix load fail continue

### DIFF
--- a/MM-control-01/Buttons.cpp
+++ b/MM-control-01/Buttons.cpp
@@ -26,11 +26,11 @@ bool settings_select_filament()
 {
     manual_extruder_selector();
 
-    if(Btn::middle == buttonClicked())
+    if(Btn::middle == buttonPressed())
     {
         shr16_set_led(2 << 2 * (4 - active_extruder));
         delay(500);
-        if (Btn::middle == buttonClicked())
+        if (Btn::middle == buttonPressed())
         {
             motion_set_idler_selector(active_extruder);
             if (active_extruder < 5) settings_bowden_length();
@@ -98,7 +98,7 @@ bool setupMenu()
         shr16_set_led(2 << 2 * _menu);
         delay(1);
 
-        switch (buttonClicked())
+        switch (buttonPressed())
         {
         case Btn::right:
             if (_menu > 0) { _menu--; delay(800); }
@@ -188,7 +188,7 @@ void settings_bowden_length()
 		do
 		{
 
-			switch (buttonClicked())
+			switch (buttonPressed())
 			{
 			case Btn::right:
 				if (!button_active || (((millis() - saved_millis) > 1000) && button_active)) {
@@ -232,7 +232,7 @@ void settings_bowden_length()
 			delay(50);
 
 
-		} while (buttonClicked() != Btn::middle);
+		} while (buttonPressed() != Btn::middle);
 
 		unload_filament_withSensor();
 	}
@@ -241,7 +241,7 @@ void settings_bowden_length()
 //! @brief Is button pushed?
 //!
 //! @return button pushed
-Btn buttonClicked()
+Btn buttonPressed()
 {
 	int raw = analogRead(ButtonPin);
 

--- a/MM-control-01/Buttons.cpp
+++ b/MM-control-01/Buttons.cpp
@@ -238,9 +238,9 @@ void settings_bowden_length()
 	}
 }
 
-//! @brief Is button pushed?
+//! @brief Is button pressed?
 //!
-//! @return button pushed
+//! @return button pressed
 Btn buttonPressed()
 {
 	int raw = analogRead(ButtonPin);
@@ -252,3 +252,16 @@ Btn buttonPressed()
 	return Btn::none;
 }
 
+//! @brief Was button clicked?
+//!
+//! If is buttonPressed, waits until it is released.
+//! @return button clicked
+Btn buttonClicked()
+{
+    Btn retVal = buttonPressed();
+    if (retVal != Btn::none)
+    {
+        while (buttonPressed() != Btn::none);
+    }
+    return retVal;
+}

--- a/MM-control-01/Buttons.h
+++ b/MM-control-01/Buttons.h
@@ -30,6 +30,6 @@ inline bool operator& (Btn a, Btn b)
 }
 
 bool setupMenu();
-Btn buttonClicked();
+Btn buttonPressed();
 
 #endif //_BUTTONS_h

--- a/MM-control-01/Buttons.h
+++ b/MM-control-01/Buttons.h
@@ -31,5 +31,6 @@ inline bool operator& (Btn a, Btn b)
 
 bool setupMenu();
 Btn buttonPressed();
+Btn buttonClicked();
 
 #endif //_BUTTONS_h

--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -172,7 +172,7 @@ void check_filament_not_present()
 {
     while (digitalRead(A1) == 1)
     {
-        while (Btn::right != buttonClicked())
+        while (Btn::right != buttonPressed())
         {
             if (digitalRead(A1) == 1)
             {
@@ -282,7 +282,7 @@ void setup()
 	shr16_set_led(0x000);
 
     // check if to goto the settings menu
-    if (buttonClicked() == Btn::middle)
+    if (buttonPressed() == Btn::middle)
     {
         state = S::Setup;
     }
@@ -330,11 +330,11 @@ void manual_extruder_selector()
 {
 	shr16_set_led(1 << 2 * (4 - active_extruder));
 
-	if ((Btn::left|Btn::right) & buttonClicked())
+	if ((Btn::left|Btn::right) & buttonPressed())
 	{
 		delay(500);
 
-		switch (buttonClicked())
+		switch (buttonPressed())
 		{
 		case Btn::right:
 			if (active_extruder < 5)
@@ -386,11 +386,11 @@ void loop()
         break;
     case S::Idle:
         manual_extruder_selector();
-        if(Btn::middle == buttonClicked() && active_extruder < 5)
+        if(Btn::middle == buttonPressed() && active_extruder < 5)
         {
             shr16_set_led(2 << 2 * (4 - active_extruder));
             delay(500);
-            if (Btn::middle == buttonClicked())
+            if (Btn::middle == buttonPressed())
             {
                 motion_set_idler_selector(active_extruder);
                 feed_filament();
@@ -399,7 +399,7 @@ void loop()
         break;
     case S::Wait:
         signal_load_failure();
-        switch(buttonClicked())
+        switch(buttonPressed())
         {
         case Btn::middle:
             if (mmctl_IsOk()) state = S::WaitOk;
@@ -414,7 +414,7 @@ void loop()
         break;
     case S::WaitOk:
         signal_ok_after_load_failure();
-        switch(buttonClicked())
+        switch(buttonPressed())
         {
         case Btn::middle:
             if (!mmctl_IsOk()) state = S::Wait;

--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -399,7 +399,7 @@ void loop()
         break;
     case S::Wait:
         signal_load_failure();
-        switch(buttonPressed())
+        switch(buttonClicked())
         {
         case Btn::middle:
             if (mmctl_IsOk()) state = S::WaitOk;
@@ -414,7 +414,7 @@ void loop()
         break;
     case S::WaitOk:
         signal_ok_after_load_failure();
-        switch(buttonPressed())
+        switch(buttonClicked())
         {
         case Btn::middle:
             if (!mmctl_IsOk()) state = S::Wait;

--- a/MM-control-01/mmctl.cpp
+++ b/MM-control-01/mmctl.cpp
@@ -45,7 +45,7 @@ void feed_filament()
 		if (_c > 100) { shr16_set_led(0x000); _c = 0; _delay++; };
 
 		if (digitalRead(A1) == 1) { _loaded = true; _feed = false; };
-		if (buttonClicked() != Btn::none && _delay > 10) { _loaded = false; _feed = false; }
+		if (buttonPressed() != Btn::none && _delay > 10) { _loaded = false; _feed = false; }
 		delayMicroseconds(4000);
 	} while (_feed);
 
@@ -354,7 +354,7 @@ void load_filament_withSensor()
                 signal_ok_after_load_failure();
             }
 
-            switch (buttonClicked())
+            switch (buttonPressed())
             {
                 case Btn::left:
                     // just move filament little bit
@@ -501,7 +501,7 @@ void unload_filament_withSensor()
             delay(100);
 
 
-            switch (buttonClicked())
+            switch (buttonPressed())
             {
             case Btn::left:
                 // just move filament little bit


### PR DESCRIPTION
Wait for button release when continuing MMU load fail, so it doesn't move selector when it is held.