### PR TITLE
Make sure idler disengages - Issue #135

### DIFF
--- a/MM-control-01/mmctl.cpp
+++ b/MM-control-01/mmctl.cpp
@@ -408,7 +408,7 @@ void load_filament_withSensor()
     }
 
     motion_feed_to_bondtech();
-
+    motion_disengage_idler();
     tmc2130_disable_axis(AX_PUL, tmc2130_mode);
     isFilamentLoaded = true;  // filament loaded
 }

--- a/MM-control-01/mmctl.cpp
+++ b/MM-control-01/mmctl.cpp
@@ -554,8 +554,8 @@ void unload_filament_withSensor()
             delayMicroseconds(5000);
         }
     }
-    tmc2130_disable_axis(AX_PUL, tmc2130_mode);
     motion_disengage_idler();
+    tmc2130_disable_axis(AX_PUL, tmc2130_mode);
     isFilamentLoaded = false; // filament unloaded
 }
 

--- a/MM-control-01/mmctl.cpp
+++ b/MM-control-01/mmctl.cpp
@@ -553,8 +553,8 @@ void unload_filament_withSensor()
             delayMicroseconds(5000);
         }
     }
-    motion_disengage_idler();
     tmc2130_disable_axis(AX_PUL, tmc2130_mode);
+    motion_disengage_idler();
     isFilamentLoaded = false; // filament unloaded
 }
 

--- a/MM-control-01/mmctl.cpp
+++ b/MM-control-01/mmctl.cpp
@@ -408,8 +408,9 @@ void load_filament_withSensor()
     }
 
     motion_feed_to_bondtech();
-    motion_disengage_idler();
+
     tmc2130_disable_axis(AX_PUL, tmc2130_mode);
+    motion_disengage_idler();
     isFilamentLoaded = true;  // filament loaded
 }
 


### PR DESCRIPTION
This shouldn't be needed but seems to solve the issue shown in #135

This also may not be how you want to handle the underlying issue but I have tested this to work on a 18hr long 650 or so toolchange print and a 3hr 100 toolchange print without issue of the idler not disengaging.