### PR TITLE
Homing Improved 2.0 (Shift sg_values over 1023 in right moving interval)

### DIFF
--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -58,15 +58,14 @@
 #define TMC2130_SPCR           SPI_SPCR(TMC2130_SPI_RATE, 1, 1, 1, 0)
 #define TMC2130_SPSR           SPI_SPSR(TMC2130_SPI_RATE)
 //params:
-// SG_THR stallguard treshold (sensitivity), range -128..127, real 0-3
-#define TMC2130_SG_THR_0       5
-#define TMC2130_SG_THR_1       6
-#define TMC2130_SG_THR_2       1
-// TCOOLTHRS coolstep treshold, usable range 400-600
-#define TMC2130_TCOOLTHRS_0    450
-#define TMC2130_TCOOLTHRS_1    450
-#define TMC2130_TCOOLTHRS_2    450
-
+// SG_THR stallguard treshold (sensitivity), range -64..63
+#define TMC2130_SG_THR_0       0
+#define TMC2130_SG_THR_1       10
+#define TMC2130_SG_THR_2       5
+// TCOOLTHRS coolstep treshold, usable range 0..1048575
+#define TMC2130_TCOOLTHRS_0    0
+#define TMC2130_TCOOLTHRS_1    0
+#define TMC2130_TCOOLTHRS_2    0
 //0 - PULLEY
 //1 - SELECTOR
 //2 - IDLER
@@ -75,11 +74,11 @@
 #define AX_IDL 2
 
 // currents
-#define CURRENT_HOLDING_STEALTH {1, 7, 16}
-#define CURRENT_HOLDING_NORMAL {1, 10, 22}
+#define CURRENT_HOLDING_STEALTH {0, 7, 16}
+#define CURRENT_HOLDING_NORMAL {0, 10, 22}
 #define CURRENT_RUNNING_STEALTH {35, 35, 35}
 #define CURRENT_RUNNING_NORMAL {30, 35, 35}
-#define CURRENT_HOMING {1, 35, 30}
+#define CURRENT_HOMING {0, 20, 20 }
 
 //mode
 #define HOMING_MODE 0

--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -60,8 +60,8 @@
 //params:
 // SG_THR stallguard treshold (sensitivity), range -64..63
 #define TMC2130_SG_THR_0       0
-#define TMC2130_SG_THR_1       10
-#define TMC2130_SG_THR_2       5
+#define TMC2130_SG_THR_1       25
+#define TMC2130_SG_THR_2       7
 // TCOOLTHRS coolstep treshold, usable range 0..1048575
 #define TMC2130_TCOOLTHRS_0    0
 #define TMC2130_TCOOLTHRS_1    0
@@ -78,7 +78,7 @@
 #define CURRENT_HOLDING_NORMAL {0, 3, 22}  // {?,?,570 mA}    pulley unused , selector no force necessary for holding
 #define CURRENT_RUNNING_STEALTH {35, 35, 45} // {?,?,910 mA}
 #define CURRENT_RUNNING_NORMAL {30, 35, 47} // {?,?,910 mA}
-#define CURRENT_HOMING {0, 20, 20}
+#define CURRENT_HOMING {0, 30, 20}
 
 
 //mode

--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -60,8 +60,8 @@
 //params:
 // SG_THR stallguard treshold (sensitivity), range -64..63
 #define TMC2130_SG_THR_0       0
-#define TMC2130_SG_THR_1       35
-#define TMC2130_SG_THR_2       10
+#define TMC2130_SG_THR_1       30
+#define TMC2130_SG_THR_2       9
 // TCOOLTHRS coolstep treshold, usable range 0..1048575
 #define TMC2130_TCOOLTHRS_0    0
 #define TMC2130_TCOOLTHRS_1    0

--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -60,8 +60,8 @@
 //params:
 // SG_THR stallguard treshold (sensitivity), range -64..63
 #define TMC2130_SG_THR_0       0
-#define TMC2130_SG_THR_1       25
-#define TMC2130_SG_THR_2       7
+#define TMC2130_SG_THR_1       35
+#define TMC2130_SG_THR_2       10
 // TCOOLTHRS coolstep treshold, usable range 0..1048575
 #define TMC2130_TCOOLTHRS_0    0
 #define TMC2130_TCOOLTHRS_1    0
@@ -78,7 +78,7 @@
 #define CURRENT_HOLDING_NORMAL {0, 3, 22}  // {?,?,570 mA}    pulley unused , selector no force necessary for holding
 #define CURRENT_RUNNING_STEALTH {35, 35, 45} // {?,?,910 mA}
 #define CURRENT_RUNNING_NORMAL {30, 35, 47} // {?,?,910 mA}
-#define CURRENT_HOMING {0, 30, 20}
+#define CURRENT_HOMING {0, 35, 30}
 
 
 //mode

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -29,7 +29,7 @@ static int set_pulley_direction(int _steps);
 static void set_idler_dir_down();
 static void set_idler_dir_up();
 static void move(int _idler, int _selector, int _pulley);
-
+static uint16_t sg;
 //! @brief Compute steps for selector needed to change filament
 //! @par current_filament Currently selected filament
 //! @par next_filament Filament to be selected
@@ -77,23 +77,14 @@ bool home_idler()
 
 	tmc2130_init(HOMING_MODE);
 
-	move(-10, 0, 0); // move a bit in opposite direction
-
-	for (int c = 1; c > 0; c--)  // not really functional, let's do it rather more times to be sure
-	{
-		delay(50);
-		for (int i = 0; i < 2000; i++)
+	move(-50, 0,0); // move a bit in opposite direction
+	delay(50);
+		for (int i = 0; i < 3000; i++)
 		{
+      			int _sg = sg;    
 			move(1, 0,0);
-			delayMicroseconds(100);
-			tmc2130_read_sg(0);
-
-			_c++;
-			if (i == 1000) { _l++; }
-			if (_c > 100) { shr16_set_led(1 << 2 * _l); };
-			if (_c > 200) { shr16_set_led(0x000); _c = 0; };
+     			if ((i > 50) && (sg >(_sg +250)))  break;
 		}
-	}
 
 	move(idler_steps_after_homing, 0, 0); // move to initial position
 
@@ -101,7 +92,7 @@ bool home_idler()
 
 	delay(500);
 
-    isIdlerParked = false;
+    	isIdlerParked = false;
 
 	park_idler(false);
 
@@ -114,39 +105,19 @@ bool home_selector()
     check_filament_not_present();
 
     tmc2130_init(HOMING_MODE);
-	 
-    move(0, -100,0); // move a bit in opposite direction
-
-	int _c = 0;
-	int _l = 2;
-
-	for (int c = 5; c > 0; c--)   // not really functional, let's do it rather more times to be sure
-	{
-		move(0, (c*20) * -1,0);
-		delay(50);
-		for (int i = 0; i < 4000; i++)
+    for (int i = 0; i < 4000; i++)
 		{
+      			int _sg = sg;
 			move(0, 1,0);
-			uint16_t sg = tmc2130_read_sg(1);
-			if ((i > 16) && (sg < 6))	break;
-
-			_c++;
-			if (i == 3000) { _l++; }
-			if (_c > 100) { shr16_set_led(1 << 2 * _l); };
-			if (_c > 200) { shr16_set_led(0x000); _c = 0; };
+			if ((i > 100) && (sg >(_sg +100)))	break;
 		}
-	}
-
-	move(0, selector_steps_after_homing,0); // move to initial position
-
-    tmc2130_init(tmc2130_mode);
-
-	delay(500);
-
-	return true;
+     move(0, selector_steps_after_homing,0); // move to initial position
+     tmc2130_init(tmc2130_mode);
+     delay(500);
+     return true;
 }
 
-//! @brief Home both idler and selector if already not done
+//Home both idler and selector if already not done
 void home()
 {
     home_idler();
@@ -208,28 +179,29 @@ void move_proportional(int _idler, int _selector)
 
 void move(int _idler, int _selector, int _pulley)
 {
-	int _acc = 50;
-
+  int _acc = 50;
+	
 	// gets steps to be done and set direction
 	_idler = set_idler_direction(_idler); 
 	_selector = set_selector_direction(_selector);
-	_pulley = set_pulley_direction(_pulley);
+	//_pulley = set_pulley_direction(_pulley);
 	
 
-	do
+	while(_selector != 0 || _idler != 0)
 	{
-		if (_idler > 0) { idler_step_pin_set(); }
-		if (_selector > 0) { selector_step_pin_set();}
-		if (_pulley > 0) { pulley_step_pin_set(); }
+    delayMicroseconds(10);
+		if (_idler > 0) { idler_step_pin_set();sg = tmc2130_read_sg(2); }
+		if (_selector > 0) { selector_step_pin_set();sg = tmc2130_read_sg(1);}
+		//if (_pulley > 0) { pulley_step_pin_set(); }
 		asm("nop");
-		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(1000); }
-		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(800); }
-		if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
+		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(1000);}
+		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(1000);}
+		//if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
 		asm("nop");
 
 		if (_acc > 0) { delayMicroseconds(_acc*10); _acc = _acc - 1; }; // super pseudo acceleration control
 
-	} while (_selector != 0 || _idler != 0 || _pulley != 0);
+	}
 }
 
 

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -189,11 +189,11 @@ void move(int _idler, int _selector, int _pulley)
 	while(_selector != 0 || _idler != 0)
 	{
 		if (_idler > 0) { idler_step_pin_set();sg = tmc2130_read_sg(2); }
-		if (_selector > 0) { selector_step_pin_set();sg = tmc2130_read_sg(1);}
+		if (_selector > 0) { selector_step_pin_set();sg = tmc2130_read_sg(1); }
 		if (_pulley > 0) { pulley_step_pin_set(); }
 		asm("nop");
-		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(1000);}
-		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(1000);}
+		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(1000); }
+		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(1000); }
 		if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
 		asm("nop");
 

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -196,8 +196,8 @@ void move(int _idler, int _selector, int _pulley)
 		if (_selector > 0) { selector_step_pin_set();sg_selector = tmc2130_read_sg(AX_SEL);}
 		if (_pulley > 0) { pulley_step_pin_set(); }  
 		asm("nop");
-		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(50);}
-		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(50);}
+		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(100);}
+		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(200);}
 		if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
 		asm("nop");
 

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -86,7 +86,7 @@ bool home_idler()
      			if ((i > 50) && (sg >(_sg +250)))  break;
 		}
 	tmc2130_init(tmc2130_mode);
-	move(idler_steps_after_homing, 0, 0); // move to initial position
+	move_proportional(idler_steps_after_homing, 0, 0); // move to initial position
 		
     	isIdlerParked = false;
 
@@ -112,7 +112,7 @@ bool home_selector()
 
 		}
      tmc2130_init(tmc2130_mode);
-     move(0, selector_steps_after_homing,0); // move to initial position
+     move_proportional(0, selector_steps_after_homing,0); // move to initial position
      return true;
 }
 

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -113,7 +113,7 @@ bool home_selector()
       			int _sg_selector = sg_selector;
 			move(0, 1,0);
 
-			if ((i > 100) && (sg_selector <(_sg_selector -200)))	break;
+			if ((i > 100) && (sg_selector <(_sg_selector -100)))	break;
 		}
      tmc2130_init(tmc2130_mode);
      move_proportional(0, selector_steps_after_homing); // move to initial position

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -113,7 +113,7 @@ bool home_selector()
       			int _sg_selector = sg_selector;
 			move(0, 1,0);
 
-			if ((i > 100) && (sg_selector <(_sg_selector -250)))	break;
+			if ((i > 100) && (sg_selector <(_sg_selector -200)))	break;
 		}
      tmc2130_init(tmc2130_mode);
      move_proportional(0, selector_steps_after_homing); // move to initial position

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -29,7 +29,12 @@ static int set_pulley_direction(int _steps);
 static void set_idler_dir_down();
 static void set_idler_dir_up();
 static void move(int _idler, int _selector, int _pulley);
-static uint16_t sg;
+static int _sg_idler;
+static int _sg_selector;
+static int _sg_pulley;
+uint16_t sg_selector;
+uint16_t sg_idler;
+uint16_t sg_pulley;
 //! @brief Compute steps for selector needed to change filament
 //! @par current_filament Currently selected filament
 //! @par next_filament Filament to be selected
@@ -81,9 +86,9 @@ bool home_idler()
 	delay(50);
 		for (int i = 0; i < 3000; i++)
 		{
-      			int _sg = sg;    
+      			int  _sg_idler = sg_idler; 
 			move(1, 0,0);
-     			if ((i > 50) && (sg >(_sg +250)))  break;
+     			if ((i > 50) && (sg_idler <(_sg_idler -200)))  break;
 		}
 	tmc2130_init(tmc2130_mode);
 	move_proportional(idler_steps_after_homing, 0); // move to initial position
@@ -105,11 +110,10 @@ bool home_selector()
     for (int i = 0; i < 4000; i++)
 
 		{
-      			int _sg = sg;
+      			int _sg_selector = sg_selector;
 			move(0, 1,0);
 
-			if ((i > 100) && (sg >(_sg +100)))	break;
-
+			if ((i > 100) && (sg_selector <(_sg_selector -250)))	break;
 		}
      tmc2130_init(tmc2130_mode);
      move_proportional(0, selector_steps_after_homing); // move to initial position
@@ -188,12 +192,12 @@ void move(int _idler, int _selector, int _pulley)
 
 	while(_selector != 0 || _idler != 0)
 	{
-		if (_idler > 0) { idler_step_pin_set();sg = tmc2130_read_sg(2); }
-		if (_selector > 0) { selector_step_pin_set();sg = tmc2130_read_sg(1); }
-		if (_pulley > 0) { pulley_step_pin_set(); }
+		if (_idler > 0) { idler_step_pin_set();sg_idler = tmc2130_read_sg(AX_IDL); }
+		if (_selector > 0) { selector_step_pin_set();sg_selector = tmc2130_read_sg(AX_SEL);}
+		if (_pulley > 0) { pulley_step_pin_set(); }  
 		asm("nop");
-		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(1000); }
-		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(1000); }
+		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(50);}
+		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(50);}
 		if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
 		asm("nop");
 

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -85,13 +85,9 @@ bool home_idler()
 			move(1, 0,0);
      			if ((i > 50) && (sg >(_sg +250)))  break;
 		}
-
-	move(idler_steps_after_homing, 0, 0); // move to initial position
-
 	tmc2130_init(tmc2130_mode);
-
-	delay(500);
-
+	move(idler_steps_after_homing, 0, 0); // move to initial position
+		
     	isIdlerParked = false;
 
 	park_idler(false);
@@ -115,9 +111,8 @@ bool home_selector()
 			if ((i > 100) && (sg >(_sg +100)))	break;
 
 		}
-     move(0, selector_steps_after_homing,0); // move to initial position
      tmc2130_init(tmc2130_mode);
-     delay(500);
+     move(0, selector_steps_after_homing,0); // move to initial position
      return true;
 }
 
@@ -188,19 +183,18 @@ void move(int _idler, int _selector, int _pulley)
 	// gets steps to be done and set direction
 	_idler = set_idler_direction(_idler); 
 	_selector = set_selector_direction(_selector);
-	//_pulley = set_pulley_direction(_pulley);
+	_pulley = set_pulley_direction(_pulley);
 	
 
 	while(_selector != 0 || _idler != 0)
 	{
-    delayMicroseconds(10);
 		if (_idler > 0) { idler_step_pin_set();sg = tmc2130_read_sg(2); }
 		if (_selector > 0) { selector_step_pin_set();sg = tmc2130_read_sg(1);}
-		//if (_pulley > 0) { pulley_step_pin_set(); }
+		if (_pulley > 0) { pulley_step_pin_set(); }
 		asm("nop");
 		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(1000);}
 		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(1000);}
-		//if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
+		if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
 		asm("nop");
 
 		if (_acc > 0) { delayMicroseconds(_acc*10); _acc = _acc - 1; }; // super pseudo acceleration control

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -86,7 +86,7 @@ bool home_idler()
      			if ((i > 50) && (sg >(_sg +250)))  break;
 		}
 	tmc2130_init(tmc2130_mode);
-	move_proportional(idler_steps_after_homing, 0, 0); // move to initial position
+	move_proportional(idler_steps_after_homing, 0); // move to initial position
 		
     	isIdlerParked = false;
 
@@ -112,7 +112,7 @@ bool home_selector()
 
 		}
      tmc2130_init(tmc2130_mode);
-     move_proportional(0, selector_steps_after_homing,0); // move to initial position
+     move_proportional(0, selector_steps_after_homing); // move to initial position
      return true;
 }
 


### PR DESCRIPTION
increased SG_THR stallguard treshold until normal moving results in a value over 1023. when it crash at the end the value fall so it is recognizable.
and with this homing you can tune the correct tension of the idler's springs: if it clink the tension is eccessive and you have to unscrew a bit until homing idler work fine.