### PR TITLE
Fix homing without hardware modification

### DIFF
--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -61,7 +61,7 @@
 // SG_THR stallguard treshold (sensitivity), range -128..127, real 0-3
 #define TMC2130_SG_THR_0       5
 #define TMC2130_SG_THR_1       6
-#define TMC2130_SG_THR_2       1
+#define TMC2130_SG_THR_2       10
 // TCOOLTHRS coolstep treshold, usable range 400-600
 #define TMC2130_TCOOLTHRS_0    450
 #define TMC2130_TCOOLTHRS_1    450
@@ -74,12 +74,22 @@
 #define AX_SEL 1
 #define AX_IDL 2
 
-// currents
-#define CURRENT_HOLDING_STEALTH {1, 7, 22}  // {?,?,570 mA}
-#define CURRENT_HOLDING_NORMAL {1, 10, 22}  // {?,?,570 mA}
-#define CURRENT_RUNNING_STEALTH {35, 35, 45} // {?,?,910 mA}
-#define CURRENT_RUNNING_NORMAL {30, 35, 47} // {?,?,910 mA}
-#define CURRENT_HOMING {1, 35, 30}
+// currents (R 0.22) 
+// registers are from 0 to 31 only
+// 0=1/32 31=32/32 from 0.96A with vsense=0 0.53A with vsense=1
+// if current running <=31 vsense=1 
+// if its more then its rigth shifted 1 bit
+//           000 001 002 003 004 005 006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 025 026 027 028 029 030 031
+// vsense=1  017 033 050 066 083 099 116 133 149 166 182 199 215 232 248 265 282 298 315 331 348 364 381 398 414 431 447 464 480 497 513 530
+// vsense=0  030 060 090 120 150 180 210 240 270 300 330 360 390 420 450 480 510 540 570 600 630 660 690 720 750 780 810 840 870 900 930 960
+//
+//           032 033 034 035 036 037 038 039 040 041 042 043 044 045 046 047 048 049 050 051 052 053 054 055 056 057 058 059 060 061 062 063
+//           510 510 540 540 570 570 600 600 630 630 660 660 690 690 720 720 750 750 780 780 810 810 840 840 870 870 900 900 930 930 960 960    
+#define CURRENT_HOLDING_STEALTH {1, 7, 22}  // {60,240,690 mA}
+#define CURRENT_HOLDING_NORMAL {1, 10, 22}  // {17,330,690 mA}
+#define CURRENT_RUNNING_STEALTH {35, 35, 45} // {540,540,690 mA}
+#define CURRENT_RUNNING_NORMAL {30, 35, 47} // {513,540,720 mA}
+#define CURRENT_HOMING {1, 35, 30} //
 
 //mode
 #define HOMING_MODE 0

--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -392,9 +392,9 @@ void loop()
         if(Btn::middle == buttonPressed() && active_extruder < 5)
         {
             delay(500);
-            shr16_set_led(2 << 2 * (4 - active_extruder));
             if (Btn::middle == buttonPressed())
             {
+                shr16_set_led(2 << 2 * (4 - active_extruder));
                 motion_set_idler_selector(active_extruder);
                 feed_filament();
             }

--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -297,6 +297,8 @@ void setup()
     }
 
 	if (digitalRead(A1) == 1) isFilamentLoaded = true;
+  shr16_set_led(1 << 2 * (4 - active_extruder));
+
 
 }
 
@@ -329,7 +331,6 @@ void setup()
 //! @n b - blinking
 void manual_extruder_selector()
 {
-	shr16_set_led(1 << 2 * (4 - active_extruder));
 
 	if ((Btn::left|Btn::right) & buttonPressed())
 	{
@@ -350,6 +351,7 @@ void manual_extruder_selector()
 		default:
 			break;
 		}
+    shr16_set_led(1 << 2 * (4 - active_extruder));
 		delay(500);
 	}
 

--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -293,6 +293,7 @@ void setup()
     if(FilamentLoaded::get(filament))
     {
         motion_set_idler(filament);
+        active_extruder=filament; // set active extruder to eeprom stored filament
     }
 
 	if (digitalRead(A1) == 1) isFilamentLoaded = true;

--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -391,8 +391,8 @@ void loop()
         manual_extruder_selector();
         if(Btn::middle == buttonPressed() && active_extruder < 5)
         {
-            shr16_set_led(2 << 2 * (4 - active_extruder));
             delay(500);
+            shr16_set_led(2 << 2 * (4 - active_extruder));
             if (Btn::middle == buttonPressed())
             {
                 motion_set_idler_selector(active_extruder);

--- a/MM-control-01/mmctl.cpp
+++ b/MM-control-01/mmctl.cpp
@@ -643,6 +643,7 @@ void unload_filament_withSensor()
     motion_disengage_idler();
     tmc2130_disable_axis(AX_PUL, tmc2130_mode);
     isFilamentLoaded = false; // filament unloaded
+    FilamentLoaded::set(5); // remove loaded filament from eeprom
 }
 
 //! @brief Do 38.20 mm pulley push

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -81,10 +81,10 @@ bool home_idler()
 
 	move(-10, 0, 0); // move a bit in opposite direction
 
-	for (int c = 5; c > 0; c--)  // not really functional, let's do it rather more times to be sure
+	for (int c = 1; c > 0; c--)  // not really functional, let's do it rather more times to be sure
 	{
 		delay(50);
-		move_with_stallguard(2000, 0,0,1);
+		move_with_stallguard(2000, 0,0,0);
     //move(200, 0, 0); // move a bit in direction
 
 	}
@@ -110,7 +110,7 @@ bool home_selector()
 
 	int _c = 0;
   shr16_set_led(2 << 2 * 2);
-	for (int c = 7; c > 0; c--)   // not really functional, let's do it rather more times to be sure
+	for (int c = 5; c > 0; c--)   // not really functional, let's do it rather more times to be sure
 	{
 		move(0, c * -18, 0);
 		delay(50);

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -238,7 +238,6 @@ void move_with_stallguard(int _idler, int _selector, int _pulley, int _sg)
     if (_idler > 0 && _acc <34) {sg_idler= tmc2130_read_sg(AX_IDL);}
     if (_selector > 0 && _acc <34) {sg_selector= tmc2130_read_sg(AX_SEL);}
     if (_pulley > 0 && _acc <34) {sg_pulley= tmc2130_read_sg(AX_PUL);}
-    printf("%u ",sg_idler);
     if((sg_selector <= _sg || sg_idler <= _sg || sg_pulley <= _sg) && _sg > 0){break;}
     if (_acc > 0) { delayMicroseconds(_acc*10); _acc--; }; // super pseudo acceleration control
 

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -29,6 +29,7 @@ static int set_pulley_direction(int _steps);
 static void set_idler_dir_down();
 static void set_idler_dir_up();
 static void move(int _idler, int _selector, int _pulley);
+static void move_with_stallguard(int _idler, int _selector, int _pulley, int _sg);
 
 //! @brief Compute steps for selector needed to change filament
 //! @par current_filament Currently selected filament
@@ -76,25 +77,18 @@ bool home_idler()
 	int _l = 0;
 
 	tmc2130_init(HOMING_MODE);
+  shr16_set_led(2 << 2 * 0);
 
 	move(-10, 0, 0); // move a bit in opposite direction
 
-	for (int c = 1; c > 0; c--)  // not really functional, let's do it rather more times to be sure
+	for (int c = 5; c > 0; c--)  // not really functional, let's do it rather more times to be sure
 	{
 		delay(50);
-		for (int i = 0; i < 2000; i++)
-		{
-			move(1, 0,0);
-			delayMicroseconds(100);
-			tmc2130_read_sg(0);
+		move_with_stallguard(2000, 0,0,1);
+    //move(200, 0, 0); // move a bit in direction
 
-			_c++;
-			if (i == 1000) { _l++; }
-			if (_c > 100) { shr16_set_led(1 << 2 * _l); };
-			if (_c > 200) { shr16_set_led(0x000); _c = 0; };
-		}
 	}
-
+  shr16_set_led(2 << 2 * 1);
 	move(idler_steps_after_homing, 0, 0); // move to initial position
 
 	tmc2130_init(tmc2130_mode);
@@ -104,7 +98,6 @@ bool home_idler()
     isIdlerParked = false;
 
 	park_idler(false);
-
 	return true;
 }
 
@@ -116,31 +109,20 @@ bool home_selector()
     tmc2130_init(HOMING_MODE);
 
 	int _c = 0;
-	int _l = 2;
-
+  shr16_set_led(2 << 2 * 2);
 	for (int c = 7; c > 0; c--)   // not really functional, let's do it rather more times to be sure
 	{
 		move(0, c * -18, 0);
 		delay(50);
-		for (int i = 0; i < 4000; i++)
-		{
-			move(0, 1,0);
-			uint16_t sg = tmc2130_read_sg(AX_SEL);
-			if ((i > 16) && (sg < 5))	break;
+		move_with_stallguard(0, 4000,0,5);
 
-			_c++;
-			if (i == 3000) { _l++; }
-			if (_c > 100) { shr16_set_led(1 << 2 * _l); };
-			if (_c > 200) { shr16_set_led(0x000); _c = 0; };
-		}
 	}
-
+  shr16_set_led(2 << 2 * 3);
 	move(0, selector_steps_after_homing,0); // move to initial position
 
     tmc2130_init(tmc2130_mode);
 
 	delay(500);
-
 	return true;
 }
 
@@ -229,7 +211,39 @@ void move(int _idler, int _selector, int _pulley)
 
 	} while (_selector != 0 || _idler != 0 || _pulley != 0);
 }
+//_sg=0 is stallguard off
+void move_with_stallguard(int _idler, int _selector, int _pulley, int _sg)
+{
+  int _acc = 50;
+  uint16_t sg_selector=1023;
+  uint16_t sg_idler=1023;
+  uint16_t sg_pulley=1023;
 
+  // gets steps to be done and set direction
+  _idler = set_idler_direction(_idler); 
+  _selector = set_selector_direction(_selector);
+  _pulley = set_pulley_direction(_pulley);
+  
+
+  do
+  {
+    if (_idler > 0) { idler_step_pin_set(); }
+    if (_selector > 0) { selector_step_pin_set();}
+    if (_pulley > 0) { pulley_step_pin_set(); }
+    asm("nop");
+    if (_idler > 0) { idler_step_pin_reset(); _idler--;  delayMicroseconds(1000); }
+    if (_selector > 0) { selector_step_pin_reset(); _selector--; delayMicroseconds(800); }
+    if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
+    asm("nop");
+    if (_idler > 0 && _acc <34) {sg_idler= tmc2130_read_sg(AX_IDL);}
+    if (_selector > 0 && _acc <34) {sg_selector= tmc2130_read_sg(AX_SEL);}
+    if (_pulley > 0 && _acc <34) {sg_pulley= tmc2130_read_sg(AX_PUL);}
+    printf("%u ",sg_idler);
+    if((sg_selector <= _sg || sg_idler <= _sg || sg_pulley <= _sg) && _sg > 0){break;}
+    if (_acc > 0) { delayMicroseconds(_acc*10); _acc--; }; // super pseudo acceleration control
+
+  } while (_selector != 0 || _idler != 0 || _pulley != 0);
+}
 
 void set_idler_dir_down()
 {


### PR DESCRIPTION
fix filament unload eeprom handling:

On setup idler is moved to eeprom stored loaded filament (so homing is done for idler)
but is never removed on unload. as only 0 to 4 is used 5 removes the filament on unload.
On setup if filament loaded is indicated active extruder is also set to loaded filament number.

fix motor humming and led flickering in idle mode:

leds not updated in idle mode
led set in setup

fix homing without hardware mod:

hc595 needs buffer capacitor. this is a workaround. no led updates on moving motor. so in the homing phase i had to change from green blinking leds to red steady (as done when moving selector).
added a move_with_stallguard sub to change led update behavior.

