### PR TITLE
1.0.6 - 10 Flashing light fix

### DIFF
--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -74,12 +74,12 @@
 #define AX_SEL 1
 #define AX_IDL 2
 
-// currents
+// currents (Drive?, Selector?, Idler)
 #define CURRENT_HOLDING_STEALTH {1, 7, 22}  // {?,?,570 mA}
 #define CURRENT_HOLDING_NORMAL {1, 10, 22}  // {?,?,570 mA}
 #define CURRENT_RUNNING_STEALTH {35, 35, 45} // {?,?,910 mA}
 #define CURRENT_RUNNING_NORMAL {30, 35, 47} // {?,?,910 mA}
-#define CURRENT_HOMING {1, 35, 30}
+#define CURRENT_HOMING {1, 35, 35}
 
 //mode
 #define HOMING_MODE 0

--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -77,8 +77,8 @@
 // currents (Drive?, Selector?, Idler)
 #define CURRENT_HOLDING_STEALTH {1, 7, 22}  // {?,?,570 mA}
 #define CURRENT_HOLDING_NORMAL {1, 10, 22}  // {?,?,570 mA}
-#define CURRENT_RUNNING_STEALTH {35, 35, 45} // {?,?,910 mA}
-#define CURRENT_RUNNING_NORMAL {30, 35, 47} // {?,?,910 mA}
+#define CURRENT_RUNNING_STEALTH {35, 35, 42} // {?,?,910 mA}
+#define CURRENT_RUNNING_NORMAL {30, 35, 42} // {?,?,910 mA}
 #define CURRENT_HOMING {1, 35, 35}
 
 //mode

--- a/MM-control-01/tmc2130.c
+++ b/MM-control-01/tmc2130.c
@@ -111,7 +111,7 @@ int8_t tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint
 	uint8_t fd3 = 0;
 	uint8_t rndtf = 0; //random off time
 	uint8_t chm = 0; //spreadCycle
-	uint8_t tbl = 2; //blanking time
+	uint8_t tbl = 1; //blanking time
 	if (current_r <= 31)
 	{
 		if (tmc2130_wr_CHOPCONF(axis, toff, hstrt, hend, fd3, 0, rndtf, chm, tbl, 1, 0, 0, 0, mres, intpol, 0, 0)) return -1;


### PR DESCRIPTION
After installing 1.0.6 I started getting the 10 flashing light fix pretty regularly.  It appears this is some sort of voltage drop detection.

Reviewed the changes and noticed that the currents were changed pretty significantly in 1.0.6 so I decided to drop them down.  I did also increase the homing current a little.

This seems to have fully resolved the flashing light issue for me and at least two other community members have verified the fix.  I will leave their names anonymous as to not risk voiding their warranties due to using non official firmware.  