### PR TITLE
NEW homing with led status for correct springs tensioning HW 0.4.4

### DIFF
--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -59,9 +59,9 @@
 #define TMC2130_SPSR           SPI_SPSR(TMC2130_SPI_RATE)
 //params:
 // SG_THR stallguard treshold (sensitivity), range -128..127, real 0-3
-#define TMC2130_SG_THR_0       5
-#define TMC2130_SG_THR_1       6
-#define TMC2130_SG_THR_2       1
+#define TMC2130_SG_THR_0       0
+#define TMC2130_SG_THR_1       10
+#define TMC2130_SG_THR_2       10
 // TCOOLTHRS coolstep treshold, usable range 400-600
 #define TMC2130_TCOOLTHRS_0    450
 #define TMC2130_TCOOLTHRS_1    450
@@ -79,7 +79,7 @@
 #define CURRENT_HOLDING_NORMAL {1, 10, 22}  // {?,?,570 mA}
 #define CURRENT_RUNNING_STEALTH {35, 35, 45} // {?,?,910 mA}
 #define CURRENT_RUNNING_NORMAL {30, 35, 47} // {?,?,910 mA}
-#define CURRENT_HOMING {1, 35, 30}
+#define CURRENT_HOMING {1, 20, 30}
 
 //mode
 #define HOMING_MODE 0

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -29,6 +29,12 @@ static int set_pulley_direction(int _steps);
 static void set_idler_dir_down();
 static void set_idler_dir_up();
 static void move(int _idler, int _selector, int _pulley);
+static int _sg_idler;
+static int _sg_selector;
+int16_t sg_selector;
+int16_t sg_idler;
+
+
 
 //! @brief Compute steps for selector needed to change filament
 //! @param current_filament Currently selected filament
@@ -72,40 +78,52 @@ void do_pulley_step()
 //! @retval false Failed
 bool home_idler()
 {
-	int _c = 0;
-	int _l = 0;
 
 	tmc2130_init(HOMING_MODE);
+  move(-50, 0,0); // move a bit in opposite direction
+  delay(50);
 
-	move(-10, 0, 0); // move a bit in opposite direction
+////start testing tension springs
+  for (int i = 0; i < 2; i++)
+    {
+        for (int test= 0; test< 3000; test++)
+          {
+                    _sg_idler = sg_idler;    
+                    move(1, 0,0);                  
+                    if ((test > 50) && ((_sg_idler - sg_idler) > 200))  break;
+                    if (sg_idler >650) shr16_set_led(0x155);
+                    if ((sg_idler > 400) && (sg_idler < 650)) shr16_set_led(0x3ff);
+                    if (sg_idler <400) shr16_set_led(0x2aa);
+                    delayMicroseconds(80);
+          }        
+                
+        for (int test= 0; test< 3000; test++)
+          {
+                    int  _sg_idler = sg_idler;    
+                    move(-1, 0,0);                   
+                    if ((test > 50) && ((_sg_idler - sg_idler) > 200))  break;
+                    if (sg_idler >600) shr16_set_led(0x155);
+                    if ((sg_idler > 400) && (sg_idler < 600)) shr16_set_led(0x3ff);
+                    if (sg_idler <400) shr16_set_led(0x2aa);
+                    delayMicroseconds(80);
+          }            
+    }
+    shr16_set_led(0x00);    
+////end testing tension springs
 
-	for (int c = 1; c > 0; c--)  // not really functional, let's do it rather more times to be sure
-	{
-		delay(50);
-		for (int i = 0; i < 2000; i++)
-		{
-			move(1, 0,0);
-			delayMicroseconds(100);
-			tmc2130_read_sg(0);
+    for (int i = 0; i < 3000; i++)
+    {
+     int  _sg_idler = sg_idler;  
+      move(1, 0,0);    
+      if ((i > 50) && ((_sg_idler - sg_idler) > 200))  break;
+      delayMicroseconds(80);
+    }
 
-			_c++;
-			if (i == 1000) { _l++; }
-			if (_c > 100) { shr16_set_led(1 << 2 * _l); };
-			if (_c > 200) { shr16_set_led(0x000); _c = 0; };
-		}
-	}
-
-	move(idler_steps_after_homing, 0, 0); // move to initial position
-
-	tmc2130_init(tmc2130_mode);
-
-	delay(500);
-
+    tmc2130_init(tmc2130_mode);
+    move_proportional(idler_steps_after_homing, 0); // move to initial position
     isIdlerParked = false;
-
-	park_idler(false);
-
-	return true;
+    park_idler(false);
+  	return true;
 }
 
 bool home_selector()
@@ -115,31 +133,16 @@ bool home_selector()
 
     tmc2130_init(HOMING_MODE);
 
-	int _c = 0;
-	int _l = 2;
-
-	for (int c = 7; c > 0; c--)   // not really functional, let's do it rather more times to be sure
-	{
-		move(0, c * -18, 0);
-		delay(50);
 		for (int i = 0; i < 4000; i++)
 		{
+      int _sg_selector = sg_selector;
 			move(0, 1,0);
-			uint16_t sg = tmc2130_read_sg(AX_SEL);
-			if ((i > 16) && (sg < 5))	break;
-
-			_c++;
-			if (i == 3000) { _l++; }
-			if (_c > 100) { shr16_set_led(1 << 2 * _l); };
-			if (_c > 200) { shr16_set_led(0x000); _c = 0; };
+      if ((i > 100) && ((_sg_selector - sg_selector) >150)) break;//100
 		}
-	}
+	
 
-	move(0, selector_steps_after_homing,0); // move to initial position
-
-    tmc2130_init(tmc2130_mode);
-
-	delay(500);
+  tmc2130_init(tmc2130_mode); 
+  move_proportional(0, selector_steps_after_homing); // move to initial position
 
 	return true;
 }
@@ -214,14 +217,14 @@ void move(int _idler, int _selector, int _pulley)
 	_pulley = set_pulley_direction(_pulley);
 	
 
-	do
+	while(_selector != 0 || _idler != 0 || _pulley!= 0)
 	{
-		if (_idler > 0) { idler_step_pin_set(); }
-		if (_selector > 0) { selector_step_pin_set();}
-		if (_pulley > 0) { pulley_step_pin_set(); }
+    if (_idler > 0) { idler_step_pin_set();sg_idler = tmc2130_read_sg(AX_IDL); }
+    if (_selector > 0) { selector_step_pin_set();sg_selector = tmc2130_read_sg(AX_SEL);}
+    if (_pulley > 0) { pulley_step_pin_set(); }
 		asm("nop");
-		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(1000); }
-		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(800); }
+		if (_idler > 0) { idler_step_pin_reset(); _idler--; delayMicroseconds(50); }
+		if (_selector > 0) { selector_step_pin_reset(); _selector--;  delayMicroseconds(500); }
 		if (_pulley > 0) { pulley_step_pin_reset(); _pulley--;  delayMicroseconds(700); }
 		asm("nop");
 

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -94,7 +94,7 @@ bool home_idler()
                     if (sg_idler >650) shr16_set_led(0x155);
                     if ((sg_idler > 400) && (sg_idler < 650)) shr16_set_led(0x3ff);
                     if (sg_idler <400) shr16_set_led(0x2aa);
-                    delayMicroseconds(80);
+                    delayMicroseconds(90);
           }        
                 
         for (int test= 0; test< 3000; test++)
@@ -105,7 +105,7 @@ bool home_idler()
                     if (sg_idler >600) shr16_set_led(0x155);
                     if ((sg_idler > 400) && (sg_idler < 600)) shr16_set_led(0x3ff);
                     if (sg_idler <400) shr16_set_led(0x2aa);
-                    delayMicroseconds(80);
+                    delayMicroseconds(90);
           }            
     }
     shr16_set_led(0x00);    
@@ -116,7 +116,7 @@ bool home_idler()
      int  _sg_idler = sg_idler;  
       move(1, 0,0);    
       if ((i > 50) && ((_sg_idler - sg_idler) > 200))  break;
-      delayMicroseconds(80);
+      delayMicroseconds(90);
     }
 
     tmc2130_init(tmc2130_mode);

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -94,9 +94,9 @@ bool home_idler()
                     if (sg_idler >650) shr16_set_led(0x155);
                     if ((sg_idler > 400) && (sg_idler < 650)) shr16_set_led(0x3ff);
                     if (sg_idler <400) shr16_set_led(0x2aa);
-                    delayMicroseconds(90);
+                    delayMicroseconds(50);
           }        
-                
+          
         for (int test= 0; test< 3000; test++)
           {
                     int  _sg_idler = sg_idler;    
@@ -105,8 +105,8 @@ bool home_idler()
                     if (sg_idler >600) shr16_set_led(0x155);
                     if ((sg_idler > 400) && (sg_idler < 600)) shr16_set_led(0x3ff);
                     if (sg_idler <400) shr16_set_led(0x2aa);
-                    delayMicroseconds(90);
-          }            
+                    delayMicroseconds(50);
+          }                  
     }
     shr16_set_led(0x00);    
 ////end testing tension springs
@@ -116,9 +116,8 @@ bool home_idler()
      int  _sg_idler = sg_idler;  
       move(1, 0,0);    
       if ((i > 50) && ((_sg_idler - sg_idler) > 200))  break;
-      delayMicroseconds(90);
+      delayMicroseconds(50);
     }
-
     tmc2130_init(tmc2130_mode);
     move_proportional(idler_steps_after_homing, 0); // move to initial position
     isIdlerParked = false;


### PR DESCRIPTION
NEW homing with led status for correct springs tensioning. TESTED on ORIGINAL MMU2 with mainboard HW 0.4.4 and on a crappy cinese cloned mmu2 with mainboard 0.3 upgraded with capacitors 104 on shift registers..  
doesn't work without capacitors on 0.3 hardware. 

The tune is done with all filaments loaded. If correct tuning is done orange leds will blink only at endstops.