### PR TITLE
Added optional arguments to the F command giving load/unload speed

### DIFF
--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -455,6 +455,9 @@ void process_commands(FILE* inout)
 	}
 	int value = 0;
 	int value0 = 0;
+	int value1 = 0;
+	int value2 = 0;
+	int nr; // number of matched items
 
 	if ((count > 0) && (c == 0))
 	{
@@ -530,12 +533,24 @@ void process_commands(FILE* inout)
 			    fprintf_P(inout, PSTR("%dok\n"), DriveError::get());
 		}
 		//! F<nr.> \<type\> filament type. <nr.> filament number, \<type\> 0, 1 or 2. Does nothing.
-		else if (sscanf_P(line, PSTR("F%d %d"), &value, &value0) > 0)
+		else if ((nr = sscanf_P(line, PSTR("F%d %d %d %d"),
+					&value, &value0,
+					&value1, &value2)) > 0)
 		{
 			if (((value >= 0) && (value < EXTRUDERS)) &&
 				((value0 >= 0) && (value0 <= 2)))
 			{
 				filament_type[value] = value0;
+				if (nr == 4)
+				  {
+				    filament_load_speed[value] = value1 / 256.0;
+				    filament_unload_speed[value] = value2 / 256.0;
+				  }
+				else
+				  {
+				    filament_load_speed[value] = 1.0;
+				    filament_unload_speed[value] = 1.0;
+				  }
 				fprintf_P(inout, PSTR("ok\n"));
 			}
 		}

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -13,6 +13,8 @@
 #include "tmc2130.h"
 
 int8_t filament_type[EXTRUDERS] = {-1, -1, -1, -1, -1};
+float filament_load_speed[EXTRUDERS] = {1.0, 1.0, 1.0, 1.0, 1.0};
+float filament_unload_speed[EXTRUDERS] = {1.0, 1.0, 1.0, 1.0, 1.0};
 static bool isIdlerParked = false;
 
 static const int selector_steps_after_homing = -3700;

--- a/MM-control-01/stepper.h
+++ b/MM-control-01/stepper.h
@@ -8,6 +8,8 @@
 #include <inttypes.h>
 
 extern int8_t filament_type[EXTRUDERS];
+extern float filament_load_speed[EXTRUDERS];
+extern float filament_unload_speed[EXTRUDERS];
 
 void home();
 bool home_idler();


### PR DESCRIPTION
This supports a corresponding extension of the printer M403 command (see PR #2914 in Prusa-Firmware MK3 branch).

Speeds are given as a factor compared to normal speed such that, e.g., 0.5 means half speed. In order to avoid having to enable scanf_flt, speeds are given in 16 bit fixed point arithmetic with bit 8 being ones, so 1.0 is transmitted as 256.
