### PR TITLE
Delay initialization past 24V supply rail ready.

### DIFF
--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -240,7 +240,7 @@ void unrecoverable_error()
 //!
 //! RG | RG | RG | RG | RG | meaning
 //! -- | -- | -- | -- | -- | ------------------------
-//! 00 | 00 | 00 | 00 | 0b | Shift register initialized
+//! 00 | 00 | 00 | 00 | 0b | Shift register initialized, waiting for 24V supply rail
 //! 00 | 00 | 00 | 0b | 00 | uart initialized
 //! 00 | 00 | 0b | 00 | 00 | spi initialized
 //! 00 | 0b | 00 | 00 | 00 | tmc2130 initialized
@@ -255,7 +255,23 @@ void setup()
 {
     permanentStorageInit();
 	shr16_init(); // shift register
-	led_blink(0);
+
+	shr16_set_ena(0); //disable motors
+
+    // wait until +24V reaches at least 10V
+	{
+		constexpr int ten_volts = 10 / 5 * 1024 * 1 / 11;
+		int raw_supply_voltage = 0;
+		do
+		{
+			led_blink(0);
+			raw_supply_voltage = analogRead(A0);
+		}
+		while(raw_supply_voltage < ten_volts);
+	}
+
+	shr16_set_ena(7); //enable motors
+
 
 	uart0_init(); //uart0
 	uart1_init(); //uart1

--- a/MM-control-01/main.cpp
+++ b/MM-control-01/main.cpp
@@ -260,14 +260,19 @@ void setup()
 
     // wait until +24V reaches at least 10V
 	{
-		constexpr int ten_volts = 10 / 5 * 1024 * 1 / 11;
+		constexpr double ten_volts = 10;
+		constexpr double Vref = 5;
+		constexpr double ADCresolution = 1024;
+		constexpr double R17_kOhm = 1;
+		constexpr double R16_kOhm = 10;
+		constexpr int ten_volts_raw = ten_volts / Vref * ADCresolution * R17_kOhm / (R17_kOhm + R16_kOhm);
 		int raw_supply_voltage = 0;
 		do
 		{
 			led_blink(0);
 			raw_supply_voltage = analogRead(A0);
 		}
-		while(raw_supply_voltage < ten_volts);
+		while(raw_supply_voltage < ten_volts_raw);
 	}
 
 	shr16_set_ena(7); //enable motors


### PR DESCRIPTION
Proof of concept that motors can be disabled until 24V supply rail
(nominal voltage 12V for MK2.5) reaches sufficient voltage.