### PR TITLE
select proper linkage for each 'inline' function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ set(SOURCES
 	MM-control-01/motion.cpp
 	MM-control-01/stepper.cpp
 	MM-control-01/main.cpp
+	MM-control-01/pins.c
+	MM-control-01/spi.c
 	MM-control-01/tmc2130.c
 	MM-control-01/permanent_storage.cpp
 	MM-control-01/Buttons.cpp

--- a/MM-control-01/abtn3.c
+++ b/MM-control-01/abtn3.c
@@ -10,7 +10,7 @@ uint8_t abtn_state = 0;
 uint8_t abtn_click = 0;
 
 
-inline uint8_t abtn3_sample(void)
+static inline uint8_t abtn3_sample(void)
 {
 	int raw = adc_val[0];
 	// Button 1 - 0

--- a/MM-control-01/pins.c
+++ b/MM-control-01/pins.c
@@ -1,0 +1,16 @@
+#include <avr/io.h>
+#include "pins.h"
+
+const uint8_t selector_step_pin = 0x10;
+const uint8_t idler_step_pin = 0x40;
+const uint8_t pulley_step_pin = 0x10;
+
+extern inline void selector_step_pin_init();
+extern inline void selector_step_pin_set();
+extern inline void selector_step_pin_reset();
+extern inline void idler_step_pin_init();
+extern inline void idler_step_pin_set();
+extern inline void idler_step_pin_reset();
+extern inline void pulley_step_pin_init();
+extern inline void pulley_step_pin_set();
+extern inline void pulley_step_pin_reset();

--- a/MM-control-01/pins.h
+++ b/MM-control-01/pins.h
@@ -5,7 +5,9 @@
 
 #include <stdint.h>
 
-const uint8_t selector_step_pin = 0x10;
+extern const uint8_t selector_step_pin;
+extern const uint8_t idler_step_pin;
+extern const uint8_t pulley_step_pin;
 
 inline void selector_step_pin_init()
 {
@@ -20,8 +22,6 @@ inline void selector_step_pin_reset()
     PORTD &= ~selector_step_pin;
 }
 
-const uint8_t idler_step_pin = 0x40;
-
 inline void idler_step_pin_init()
 {
     DDRD |= idler_step_pin;
@@ -34,8 +34,6 @@ inline void idler_step_pin_reset()
 {
     PORTD &= ~idler_step_pin;
 }
-
-const uint8_t pulley_step_pin = 0x10;
 
 inline void pulley_step_pin_init()
 {

--- a/MM-control-01/spi.c
+++ b/MM-control-01/spi.c
@@ -1,0 +1,5 @@
+#include "spi.h"
+
+extern inline void spi_init();
+extern inline void spi_setup(uint8_t spcr, uint8_t spsr);
+extern inline uint8_t spi_txrx(uint8_t tx);

--- a/MM-control-01/tmc2130.c
+++ b/MM-control-01/tmc2130.c
@@ -125,7 +125,7 @@ int8_t tmc2130_setup_chopper(uint8_t axis, uint8_t mres, uint8_t current_h, uint
 	return 0;
 }
 
-inline uint16_t __tcoolthrs(uint8_t axis)
+static inline uint16_t __tcoolthrs(uint8_t axis)
 {
 	switch (axis)
 	{
@@ -136,7 +136,7 @@ inline uint16_t __tcoolthrs(uint8_t axis)
 	return TMC2130_TCOOLTHRS;
 }
 
-inline int8_t __sg_thr(uint8_t axis)
+static inline int8_t __sg_thr(uint8_t axis)
 {
 	switch (axis)
 	{
@@ -147,7 +147,7 @@ inline int8_t __sg_thr(uint8_t axis)
 	return TMC2130_SG_THR;
 }
 
-inline int8_t __res(uint8_t axis)
+static inline int8_t __res(uint8_t axis)
 {
 	switch (axis)
 	{
@@ -269,7 +269,7 @@ uint16_t tmc2130_read_sg(uint8_t axis)
 }
 
 
-inline void tmc2130_cs_low(uint8_t axis)
+static inline void tmc2130_cs_low(uint8_t axis)
 {
 	switch (axis)
 	{
@@ -279,7 +279,7 @@ inline void tmc2130_cs_low(uint8_t axis)
 	}
 }
 
-inline void tmc2130_cs_high(uint8_t axis)
+static inline void tmc2130_cs_high(uint8_t axis)
 {
 	switch (axis)
 	{


### PR DESCRIPTION
As the 'inline' designation is merely a hint for a compiler, an inline function might likely actually end up being compiled on its own, in which case, the linkage specifiers become significant. Therefore, one has to be prepared for such eventuality: you can either declare the function 'static' and have it be compiled in each translation unit separately, or redeclare it with 'extern' in one translation unit. Another option is to inline it forcefully with `always_inline` attribute. Either way, it has to be dealt with.

Note: the `inline` keyword behaves differently in C++ than in C99/C11.

Fixes #181, #185