### PR TITLE
Quieten the homing sequence

### DIFF
--- a/MM-control-01/config.h
+++ b/MM-control-01/config.h
@@ -61,7 +61,7 @@
 // SG_THR stallguard treshold (sensitivity), range -128..127, real 0-3
 #define TMC2130_SG_THR_0       5
 #define TMC2130_SG_THR_1       6
-#define TMC2130_SG_THR_2       1
+#define TMC2130_SG_THR_2       9
 // TCOOLTHRS coolstep treshold, usable range 400-600
 #define TMC2130_TCOOLTHRS_0    450
 #define TMC2130_TCOOLTHRS_1    450

--- a/MM-control-01/stepper.cpp
+++ b/MM-control-01/stepper.cpp
@@ -77,36 +77,41 @@ bool home_idler()
 
 	tmc2130_init(HOMING_MODE);
 
-	move(-10, 0, 0); // move a bit in opposite direction
 
-	for (int c = 1; c > 0; c--)  // not really functional, let's do it rather more times to be sure
-	{
-		delay(50);
-		for (int i = 0; i < 2000; i++)
-		{
-			move(1, 0,0);
-			delayMicroseconds(100);
-			tmc2130_read_sg(0);
+	for (int c = 10; c > 0; c--)   // not really functional, let's do it rather more times to be sure
+  {
+    delay(50);
+    for (int i = 0; i < 4000; i++)
+    {
+      move(1, 0, 0);
+      delayMicroseconds(1000);
+      uint16_t sg = tmc2130_read_sg(AX_IDL);
+      if ((i > 50) && (sg < 1)) {
+        move(c * -18, 0, 0);
+        break;
+      }
 
-			_c++;
-			if (i == 1000) { _l++; }
-			if (_c > 100) { shr16_set_led(1 << 2 * _l); };
-			if (_c > 200) { shr16_set_led(0x000); _c = 0; };
-		}
-	}
+      _c++;
+      if (i == 3000) { _l++; }
+      if (_c > 100) { shr16_set_led(1 << 2 * _l); };
+      if (_c > 200) { shr16_set_led(0x000); _c = 0; };
+    }
+  }
 
 	move(idler_steps_after_homing, 0, 0); // move to initial position
-
+  
 	tmc2130_init(tmc2130_mode);
 
 	delay(500);
 
-    isIdlerParked = false;
+  isIdlerParked = false;
 
 	park_idler(false);
 
+  
 	return true;
 }
+
 
 bool home_selector()
 {
@@ -121,12 +126,15 @@ bool home_selector()
 	for (int c = 7; c > 0; c--)   // not really functional, let's do it rather more times to be sure
 	{
 		move(0, c * -18, 0);
-		delay(50);
+		delay(100);
 		for (int i = 0; i < 4000; i++)
 		{
 			move(0, 1,0);
+      
 			uint16_t sg = tmc2130_read_sg(AX_SEL);
-			if ((i > 16) && (sg < 5))	break;
+			if ((i > 16) && (sg < 5))	{
+			  break;
+			}
 
 			_c++;
 			if (i == 3000) { _l++; }


### PR DESCRIPTION
Enables StallGuard homing on the idler when homing. Comparatively much quieter.

Disables homing on reset and only homes when needed.

I tested it and here’s the idler homing. Turn the sound all the way up.


https://user-images.githubusercontent.com/49266685/212002977-4586f969-b290-488f-accc-dcbf7519b9d0.MOV

